### PR TITLE
Fixed 1 issue of type: PYTHON_F401 throughout 1 file in repo.

### DIFF
--- a/tcpdumpscan.py
+++ b/tcpdumpscan.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
-import encodings.idna
 import argparse
-from datetime import datetime, timedelta
+from datetime import datetime
 import json
 import os.path
 import urllib.request
@@ -11,7 +10,6 @@ import socket
 import sys
 import re
 import ssl
-import select
 import subprocess
 
 def main():
@@ -81,7 +79,6 @@ class SignalParser():
                 time.sleep(0.02)
                 sys.stdout.flush()
                 print("Failed to read from tcpdump: %s" % (str(e)))
-                pass
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        